### PR TITLE
fetch ports by svn: portsnap does not allow non-interactive use

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,13 +4,13 @@
 # For the configuration of the build environment, see Class[poudriere::env].
 
 class poudriere (
-  $zpool          = 'tank',
-  $zrootfs        = '/poudriere',
-  $freebsd_host   = 'http://ftp6.us.freebsd.org/',
-  $ccache_enable  = false,
-  $ccache_dir     = '/var/cache/ccache',
-  $poudriere_base = '/usr/local/poudriere',
-  $parallel_jobs  = $processorcount,
+  $zpool             = 'tank',
+  $zrootfs           = '/poudriere',
+  $freebsd_host      = 'http://ftp6.us.freebsd.org/',
+  $ccache_enable     = false,
+  $ccache_dir        = '/var/cache/ccache',
+  $poudriere_base    = '/usr/local/poudriere',
+  $parallel_jobs     = $processorcount,
   $port_fetch_method = 'svn',
 ){
 


### PR DESCRIPTION
The portsnap utility only allows running `portsnap fetch` interactively (to prevent people from hammering on the server). This causes an error in exec `create default ports tree` when including the class on a clean system with no existing ports tree.

A class parameter $port_fetch_method is added to choose a different way to fetch the ports tree. By default, svn is used, which works well, although it is slightly slower than portsnap.
