### PR TITLE
Change module default param for port_fetch_method

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@ class poudriere (
   $ccache_dir        = '/var/cache/ccache',
   $poudriere_base    = '/usr/local/poudriere',
   $parallel_jobs     = $processorcount,
-  $port_fetch_method = 'svn',
+  $port_fetch_method = 'portsnap',
   $http_proxy        = '',
   $ftp_proxy         = '',
   $tmpfs             = 'yes',


### PR DESCRIPTION
Previously the 'poudriere ports' command would fetch the ports using
subversion, which created a requirement on subversion being available on
the system.

This change uses the default value from the manpage of 'poudriere' to
fetch the ports using 'portsnap'.  This should mean users are able to
take advantage of the defaults with fewer parameter changes, or
dependency package installations.
