### PR TITLE
Cron support

### DIFF
--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -1,18 +1,23 @@
-# This define creates a build environment for a given release and archetecture
-# of FreeBSD.  Passing in custom options gives you the bility to turn on and
-# off certain features of your ports.  Anything that can build put in
-# make.conf, you can put here as well.
-
-# NOTE: This does not actually build the packages.  For that, you will want to
-# read the documentation.
+# This resource creates a build environment for a given release and architecture
+# of FreeBSD. Passing in custom options gives you the ability to turn on and
+# off certain features of your ports. Specific make options you would put in
+# make.conf, you can pass here as well.
+# Automatic periodic building of packages is managed with the cron_enable
+# parameter
 
 define poudriere::env (
-  $makeopts     = ["WITH_PKGNG=yes"],
-  $version      = '9.1-RELEASE',
-  $arch         = "amd64",
-  $jail         = '91amd64',
-  $pkgs         = [],
-  $pkg_makeopts = []
+  $makeopts      = [],
+  $makefile      = nil,
+  $version       = '10.0-RELEASE',
+  $arch          = 'amd64',
+  $jail          = $name,
+  $paralleljobs  = $::processorcount,
+  $pkgs          = [],
+  $pkg_file      = nil,
+  $pkg_makeopts  = {},
+  $pkg_optsdir   = nil,
+  $cron_enable   = false,
+  $cron_interval = { minute => 0, hour => 0, monthday => '*', month => '*', weekday => '*' },
 ) {
 
   # Make sure we are prepared to run
@@ -21,21 +26,65 @@ define poudriere::env (
   # Create the environment
   exec { "create ${jail} jail":
     command => "/usr/local/bin/poudriere jail -c -j ${jail} -v ${version} -a ${arch}",
-    require => Exec["create default ports tree"],
+    require => Exec['create default ports tree'],
     creates => "${poudriere::poudriere_base}/jails/${jail}/",
-    timeout => '3600',
+    timeout => 3600,
+  }
+
+  if $makefile != nil {
+    $manage_make_source = $makefile
+  }
+
+  if $makeopts != [] or $pkg_makeopts != {} {
+    $manage_make_content = template('poudriere/make.conf.erb')
   }
 
   # Lay down the configuration
   file { "/usr/local/etc/poudriere.d/${jail}-make.conf":
-    content => template('poudriere/make.conf.erb'),
-    require => File["/usr/local/etc/poudriere.d"],
+    source  => $manage_make_source,
+    content => $manage_make_content,
+    require => File['/usr/local/etc/poudriere.d'],
+  }
+
+  if $pkg_file != nil {
+    $manage_pkgs_source = $pkg_file
   }
 
   if $pkgs != [] {
-    file { "/usr/local/etc/poudriere.${jail}.list":
-      content => inline_template("<%= (@pkgs.join('\n'))+\"\n\" %>"),
-      require => File["/usr/local/etc/poudriere.d"],
+    $manage_pkgs_content = inline_template("<%= (@pkgs.join('\n'))+\"\n\" %>")
+  }
+
+  # Define list of packages to build
+  file { "/usr/local/etc/poudriere.d/${jail}.list":
+    source  => $manage_pkgs_source,
+    content => $manage_pkgs_content,
+    require => File['/usr/local/etc/poudriere.d'],
+  }
+
+  # Define optional port building options
+  if $pkg_optsdir != nil {
+    file { "/usr/local/etc/poudriere.d/${jail}-options/":
+      ensure  => directory,
+      recurse => true,
+      force   => true,
+      source  => $pkg_optsdir,
     }
+  }
+
+  # build new ports periodically
+  $cron_present = $cron_enable ? {
+    true    => 'present',
+    default => 'absent',
+  }
+
+  cron { "poudriere-bulk-${jail}":
+    ensure   => $cron_present,
+    command  => "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin poudriere bulk -f /usr/local/etc/poudriere.d/${jail}.list -j ${jail} -J ${paralleljobs}",
+    user     => 'root',
+    minute   => $cron_interval['minute'],
+    hour     => $cron_interval['hour'],
+    monthday => $cron_interval['monthday'],
+    month    => $cron_interval['month'],
+    weekday  => $cron_interval['weekday'],
   }
 }


### PR DESCRIPTION
Based on a patch pulled upstream in poudriere 3.1, we can now manage the creation and updating of ports tree from puppet as well.
I also added support for hardcoded make.conf's, package-lists and option-files, in case you don't want to define all this from hiera/puppet.
