### PR TITLE
Rework $poudriere::env::arch

### DIFF
--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -10,7 +10,7 @@ define poudriere::env (
   Array[String[1]]               $makeopts         = [],
   Optional[Stdlib::Absolutepath] $makefile         = undef,
   String[1]                      $version          = '10.0-RELEASE',
-  String[1]                      $arch             = 'amd64',
+  Optional[Poudriere::Architecture] $arch          = undef,
   String[1]                      $jail             = $name,
   Integer[1]                     $paralleljobs     = $facts['processors']['count'],
   Array[String[1]]               $pkgs             = [],
@@ -60,8 +60,12 @@ define poudriere::env (
 
   # Manage jail
   if $ensure != 'absent' {
+    $arch_arg = $arch ? {
+      Undef   => '',
+      default => "-a ${arch}",
+    }
     exec { "poudriere-jail-${jail}":
-      command => "/usr/local/bin/poudriere jail -c -j ${jail} -v ${version} -a ${arch} -p ${portstree}",
+      command => "/usr/local/bin/poudriere jail -c -j ${jail} -v ${version} ${arch_arg} -p ${portstree}",
       require => Poudriere::Portstree[$portstree],
       creates => regsubst("${poudriere::poudriere_base}/jails/${jail}/", ':', '_', 'G'),
       timeout => 3600,

--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -24,6 +24,11 @@ define poudriere::env (
 ) {
   # Make sure we are prepared to run
   include poudriere
+
+  if $facts['os']['architecture'] == 'amd64' and $arch and $arch !~ 'amd64' and $arch !~ 'i386' {
+    include poudriere::xbuild
+  }
+
   if ! defined(Poudriere::Portstree[$portstree]) {
     if $portstree == 'defaut' {
       warning('The default portstree is no longer created automatically.  Please consult the Readme file for instructions on how to create this yourself')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class poudriere (
   String                       $build_as_non_root     = '',
   Hash                         $environments          = {},
   Hash                         $portstrees            = {},
+  String[1]                    $xbuild_package        = 'qemu-user-static',
 ) {
   Exec {
     path => '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin',

--- a/manifests/xbuild.pp
+++ b/manifests/xbuild.pp
@@ -1,0 +1,14 @@
+# @summary Install cross-building dependencies
+class poudriere::xbuild {
+  include poudriere
+
+  package { $poudriere::xbuild_package:
+    ensure => installed,
+  }
+
+  service { 'qemu_user_static':
+    ensure => 'running',
+    enable => true,
+    status => '/usr/sbin/binmiscctl lookup arm',
+  }
+}

--- a/spec/classes/xbuild_spec.rb
+++ b/spec/classes/xbuild_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'poudriere::xbuild' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_package('qemu-user-static') }
+      it { is_expected.to contain_service('qemu_user_static') }
+    end
+  end
+end

--- a/spec/defines/env_spec.rb
+++ b/spec/defines/env_spec.rb
@@ -10,6 +10,18 @@ describe 'poudriere::env' do
       let(:pre_condition) { 'poudriere::portstree { "default": }' }
 
       it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_exec('poudriere-jail-foo').with(command: '/usr/local/bin/poudriere jail -c -j foo -v 10.0-RELEASE  -p default') }
+
+      context "with a custom architecture" do
+        let(:params) do
+          {
+            'arch': 'arm.armv7',
+          }
+        end
+
+        it { is_expected.to contain_exec('poudriere-jail-foo').with(command: '/usr/local/bin/poudriere jail -c -j foo -v 10.0-RELEASE -a arm.armv7 -p default') }
+      end
     end
   end
 end

--- a/spec/defines/env_spec.rb
+++ b/spec/defines/env_spec.rb
@@ -13,14 +13,27 @@ describe 'poudriere::env' do
 
       it { is_expected.to contain_exec('poudriere-jail-foo').with(command: '/usr/local/bin/poudriere jail -c -j foo -v 10.0-RELEASE  -p default') }
 
-      context "with a custom architecture" do
-        let(:params) do
-          {
-            'arch': 'arm.armv7',
-          }
+      context 'with a custom architecture' do
+        context 'when targeting armv7' do
+          let(:params) do
+            {
+              'arch': 'arm.armv7',
+            }
+          end
+
+          it { is_expected.to contain_exec('poudriere-jail-foo').with(command: '/usr/local/bin/poudriere jail -c -j foo -v 10.0-RELEASE -a arm.armv7 -p default') }
+          it { is_expected.to contain_class('poudriere::xbuild') }
         end
 
-        it { is_expected.to contain_exec('poudriere-jail-foo').with(command: '/usr/local/bin/poudriere jail -c -j foo -v 10.0-RELEASE -a arm.armv7 -p default') }
+        context 'when targeting i386' do
+          let(:params) do
+            {
+              'arch': 'i386',
+            }
+          end
+
+          it { is_expected.not_to contain_class('poudriere::xbuild') }
+        end
       end
     end
   end

--- a/types/architecture.pp
+++ b/types/architecture.pp
@@ -1,0 +1,32 @@
+# @summary The architecture to target when building packages
+#
+# @note This list can be obtained from the FreeBSD src directory with `make targets | awk -F '( +|/)' 'NR > 1 { if ($2 == $3) { print $2 }; print $2"."$3 }'`
+type Poudriere::Architecture = Enum[
+  'amd64',
+  'amd64.amd64',
+  'arm',
+  'arm.arm',
+  'arm.armv6',
+  'arm.armv7',
+  'arm64.aarch64',
+  'i386',
+  'i386.i386',
+  'mips.mipsel',
+  'mips',
+  'mips.mips',
+  'mips.mips64el',
+  'mips.mips64',
+  'mips.mipsn32',
+  'mips.mipselhf',
+  'mips.mipshf',
+  'mips.mips64elhf',
+  'mips.mips64hf',
+  'powerpc',
+  'powerpc.powerpc',
+  'powerpc.powerpc64',
+  'powerpc.powerpcspe',
+  'riscv.riscv64',
+  'riscv.riscv64sf',
+  'sparc64',
+  'sparc64.sparc64',
+]


### PR DESCRIPTION
#### Pull Request (PR) description

poudriere(8) defaults to the architecure of the host, so it makes sense
to do so in the module.  On amd64, it is possible to specify another
architecture for cross-building packages, but it is an exception, not
the rule, so existing users should be unaffected by this change.

While here, explicitely list allowed values.  This should help detect
facts which do not exactly match what is expected (I only have access to
amd64 boxes which return the expected value).


#### This Pull Request (PR) fixes the following issues

Fixes part of #52, we started discussing this in #51