### PR TITLE
Use the FreeBSD "central server" for downloads

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,7 @@
 class poudriere (
   Optional[String[1]]          $zpool                 = undef,
   Stdlib::Absolutepath         $zrootfs               = '/poudriere',
-  String[1]                    $freebsd_host          = 'http://ftp6.us.freebsd.org/',
+  String[1]                    $freebsd_host          = 'http://ftp.freebsd.org/',
   Stdlib::Absolutepath         $resolv_conf           = '/etc/resolv.conf',
   Boolean                      $ccache_enable         = false,
   Stdlib::Absolutepath         $ccache_dir            = '/var/cache/ccache',


### PR DESCRIPTION
#### Pull Request (PR) description

Instead of using a server for a particular geographic zone by default, rely on ftp.FreeBSD.org which will use the closest mirror.

Quoting [the Appendix A of the handbook]:

> The official sources for FreeBSD are available via anonymous FTP from a worldwide set of mirror sites. The site ftp://ftp.FreeBSD.org/pub/FreeBSD/ is available via HTTP and FTP. It is made up of many machines operated by the project cluster administrators and behind GeoDNS to direct users to the closest available mirror.

[the Appendix A of the handbook]: https://docs.freebsd.org/doc/12.1-RELEASE/usr/local/share/doc/freebsd/en/books/handbook/mirrors-ftp.html

#### This Pull Request (PR) fixes the following issues
n/a
