### PR TITLE
Do not hardcode a default version in poudriere::env

### DIFF
--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -5,10 +5,10 @@
 # Automatic periodic building of packages is managed with the cron_enable
 # parameter
 #
+# @param version Version of the jail
 # @param ensure The desired state of this environment
 # @param makeopts Build options
 # @param makefile Path to a Makefile
-# @param version Version of the jail
 # @param arch Architecture of the jail
 # @param jail Name of the jail
 # @param paralleljobs Override the number of builders
@@ -21,10 +21,10 @@
 # @param cron_always_mail Always send an e-mail on update
 # @param cron_interval Scheduling of automatic updates
 define poudriere::env (
+  String[1]                      $version,
   Enum['present', 'absent']      $ensure           = 'present',
   Array[String[1]]               $makeopts         = [],
   Optional[Stdlib::Absolutepath] $makefile         = undef,
-  String[1]                      $version          = '10.0-RELEASE',
   Optional[Poudriere::Architecture] $arch          = undef,
   String[1]                      $jail             = $name,
   Integer[1]                     $paralleljobs     = $facts['processors']['count'],

--- a/spec/defines/env_spec.rb
+++ b/spec/defines/env_spec.rb
@@ -9,6 +9,11 @@ describe 'poudriere::env' do
 
       let(:pre_condition) { 'poudriere::portstree { "default": }' }
 
+      let(:params) do
+        {
+          'version': '10.0-RELEASE',
+        }
+      end
       it { is_expected.to compile.with_all_deps }
 
       it { is_expected.to contain_exec('poudriere-jail-foo').with(command: '/usr/local/bin/poudriere jail -c -j foo -v 10.0-RELEASE  -p default') }
@@ -18,6 +23,7 @@ describe 'poudriere::env' do
           let(:params) do
             {
               'arch': 'arm.armv7',
+              'version': '10.0-RELEASE',
             }
           end
 
@@ -29,6 +35,7 @@ describe 'poudriere::env' do
           let(:params) do
             {
               'arch': 'i386',
+              'version': '10.0-RELEASE',
             }
           end
 


### PR DESCRIPTION
#### Pull Request (PR) description
FreeBSD 10.0 is now unsupported.  Instead of tweaking this default
version now and then, do not set a default value and require the user to
set it explicitly.

#### This Pull Request (PR) fixes the following issues
n/a