### PR TITLE
Unbreak poudriere::env::makefile

### DIFF
--- a/spec/defines/env_spec.rb
+++ b/spec/defines/env_spec.rb
@@ -18,6 +18,85 @@ describe 'poudriere::env' do
 
       it { is_expected.to contain_exec('poudriere-jail-foo').with(command: '/usr/local/bin/poudriere jail -c -j foo -v 10.0-RELEASE  -p default') }
 
+      context 'with all parameters set' do
+        let(:pre_condition) { 'poudriere::portstree { "wip": }' }
+
+        let(:params) do
+          {
+            'version': '13.0-RELEASE',
+            'ensure': 'present',
+            'makeopts': makeopts,
+            'makefile': makefile,
+            'arch': 'amd64',
+            'jail': 'test',
+            'paralleljobs': 42,
+            'pkgs': [
+              'sysutils/puppet6',
+              'sysutils/puppet7',
+            ],
+            'pkg_makeopts': pkg_makeopts,
+            'pkg_optsdir': '/usr/local/etc/poudriere.d/optdir',
+            'portstree': 'wip',
+            'cron_enable': true,
+            'cron_always_mail': true,
+            'cron_interval': {
+              'minute': 42,
+              'hour': 7,
+              'monthday': '*',
+              'month': '*',
+              'weekday': '*',
+            },
+          }
+        end
+
+        let(:makefile) { :undef }
+        let(:makeopts) do
+          [
+            'OPTIONS_SET+=PULSEAUDIO',
+            'OPTIONS_UNSET+=EXAMPLES DOCS',
+          ]
+        end
+        let(:pkg_makeopts) do
+          {
+            'sysutils/puppet6': [
+              'OPTIONS_SET+=RFACTER',
+              'OPTIONS_UNSET+=CFACTER',
+            ],
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/usr/local/etc/poudriere.d/test-make.conf').with(content: <<~CONF, source: nil) }
+          # makeopts
+          OPTIONS_SET+=PULSEAUDIO
+          OPTIONS_UNSET+=EXAMPLES DOCS
+
+          # pkg_makeopts for sysutils/puppet6
+          .if ${.CURDIR}=="/usr/ports/sysutils/puppet6"
+          OPTIONS_SET+=RFACTER
+          OPTIONS_UNSET+=CFACTER
+          .endif
+
+
+          CONF
+
+        context 'with a makefile' do
+          let(:makefile) { 'puppet:///moduldes/profile/poudriere/default-make.conf' }
+          let(:makeopts) { [] }
+          let(:pkg_makeopts) { {} }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/usr/local/etc/poudriere.d/test-make.conf').with(content: nil, source: 'puppet:///moduldes/profile/poudriere/default-make.conf') }
+        end
+
+
+        context 'with a makefile, makeopts and pkg_makeopts' do
+          let(:makefile) { 'puppet:///moduldes/profile/poudriere/default-make.conf' }
+
+          it { is_expected.to compile.and_raise_error(/\$makefile cannot be combined with \$makeopts and \$pkg_makeopts/) }
+        end
+      end
+
       context 'with a custom architecture' do
         context 'when targeting armv7' do
           let(:params) do


### PR DESCRIPTION
#### Pull Request (PR) description
The current code does not allow to use $poudriere::env::makefile,
causing catalog compilation failure.

Clarify the problem when the situation happen, allow to use a makefile
from any supported source (not only local files) and add CI to test when
all poudriere::env parameters are set.

#### This Pull Request (PR) fixes the following issues
n/a