### PR TITLE
Fix portstree detection

### DIFF
--- a/manifests/portstree.pp
+++ b/manifests/portstree.pp
@@ -45,14 +45,14 @@ define poudriere::portstree (
     }
     exec { "poudriere-portstree-${portstree}":
       command => "/usr/local/bin/poudriere ports -c -p ${portstree} -m ${fetch_method} ${branch_option} ${mountpoint_option}",
-      creates => "${poudriere::poudriere_base}/ports/${portstree}",
+      unless  => "/usr/local/bin/poudriere ports -lnq | /usr/bin/grep -w '^${portstree}'",
       timeout => 3600,
       require => File['/usr/local/etc/poudriere.conf'],
     }
   } else {
     exec { "poudriere-portstree-${portstree}":
       command => "/usr/local/bin/poudriere ports -d -p ${portstree}",
-      onlyif  => "/usr/local/bin/poudriere ports -l | /usr/bin/grep -w '^${portstree}'",
+      onlyif  => "/usr/local/bin/poudriere ports -lnq | /usr/bin/grep -w '^${portstree}'",
     }
   }
   if $cron_always_mail {


### PR DESCRIPTION
#### Pull Request (PR) description
With this change, we use the same method to check if a portstree is
present or absent: query poudriere for the list of port trees and search
into that list.

The previous way of looking for a ports tree presence by testing the
existence of a directory does not work when using poudriere::portstree's
mountpoint parameter:

```puppet
class profile::poudriere (
  String $zpool,
) {
  class { 'poudriere':
    zpool           => $zpool,
    freebsd_host    => 'http://ftp.FreeBSD.org/',
    ccache_enable   => true,
    use_portlint    => 'yes',
    allow_make_jobs => 'yes',
  }

  class { 'poudriere::xbuild':
  }

  poudriere::portstree { 'default':
    ensure       => present,
    fetch_method => 'null',
    mountpoint   => '/home/romain/FreeBSD/ports',
  }
}
```

While here, tune the poudriere ports parameters to only list portstree
names without metadata nor column titles.

#### This Pull Request (PR) fixes the following issues
n/a