### PR TITLE
allow to build with port outside of /usr/ports

### DIFF
--- a/spec/defines/env_spec.rb
+++ b/spec/defines/env_spec.rb
@@ -73,7 +73,7 @@ OPTIONS_SET+=PULSEAUDIO
 OPTIONS_UNSET+=EXAMPLES DOCS
 
 # pkg_makeopts for sysutils/puppet6
-.if ${.CURDIR}=="/usr/ports/sysutils/puppet6"
+.if ${.CURDIR:M*/sysutils/puppet6}
 OPTIONS_SET+=RFACTER
 OPTIONS_UNSET+=CFACTER
 .endif

--- a/templates/make.conf.epp
+++ b/templates/make.conf.epp
@@ -6,7 +6,7 @@
 
 <% $pkg_makeopts.each |$pkg, $pkg_makeopts| { -%>
 # pkg_makeopts for <%= $pkg %>
-.if ${.CURDIR}=="/usr/ports/<%= $pkg %>"
+.if ${.CURDIR:M*/<%= $pkg %>}
 <% $pkg_makeopts.each |$makeopt| { -%>
 <%= $makeopt %>
 <% } -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Allow to have port directory outside of /usr/ports

#### This Pull Request (PR) fixes the following issues
NA